### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ To install OpenSCAD via homebrew, please use the package maintained
 by the homebrew team at https://github.com/Homebrew/homebrew-cask:
 
 ```
-  brew cask install openscad
+  brew install --cask openscad
 ```


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524